### PR TITLE
fix notification bomb issue

### DIFF
--- a/main.go
+++ b/main.go
@@ -128,8 +128,7 @@ type AppState struct {
 func NewAppState(dataDir string) (*AppState, error) {
 	dataDir = filepath.Join(dataDir, "sprig")
 	// NOTE: time has to be converted from nanoseconds to milliseconds for Arbor's specifications
-	TimeLocation, _ := time.LoadLocation("UTC")
-	TimeLaunched := uint64(time.Now().In(TimeLocation).UnixNano() / 1000000)
+	TimeLaunched := uint64(time.Now().UnixNano() / 1000000)
 	var baseStore forest.Store
 	var err error
 	if err = os.MkdirAll(dataDir, 0770); err != nil {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"time"
 
 	"gioui.org/app"
 	"gioui.org/f32"
@@ -120,11 +121,15 @@ type AppState struct {
 	Settings
 	ArborState
 	*sprigTheme.Theme
-	DataDir string
+	DataDir      string
+	TimeLaunched uint64
 }
 
 func NewAppState(dataDir string) (*AppState, error) {
 	dataDir = filepath.Join(dataDir, "sprig")
+	// NOTE: time has to be converted from nanoseconds to milliseconds for Arbor's specifications
+	TimeLocation, _ := time.LoadLocation("UTC")
+	TimeLaunched := uint64(time.Now().In(TimeLocation).UnixNano() / 1000000)
 	var baseStore forest.Store
 	var err error
 	if err = os.MkdirAll(dataDir, 0770); err != nil {
@@ -158,8 +163,9 @@ func NewAppState(dataDir string) (*AppState, error) {
 			ReplyList:         rl,
 			CommunityList:     cl,
 		},
-		DataDir: dataDir,
-		Theme:   sprigTheme.New(),
+		DataDir:      dataDir,
+		Theme:        sprigTheme.New(),
+		TimeLaunched: TimeLaunched,
 	}
 	appState.Settings.dataDir = dataDir
 	jsonSettings, err := ioutil.ReadFile(appState.Settings.SettingsFile())

--- a/notifications.go
+++ b/notifications.go
@@ -26,6 +26,10 @@ func NewNotificationManager(state *AppState) (*NotificationManager, error) {
 }
 
 func (n *NotificationManager) ShouldNotify(reply *forest.Reply) bool {
+	if uint64(reply.Created) < n.AppState.TimeLaunched {
+		// do not send old notifications
+		return false
+	}
 	if reply.TreeDepth() == 1 {
 		// Notify of new conversation
 		return true


### PR DESCRIPTION
This pull request fixes issue #2.

### Implementation
It is implemented by remembering when the client started. All messages are then compared to the startup time to ensure all old notifications are silenced.

### Modified Behavior
Only messages sent while the client is running will display notifications.

### Side Note
The Go linter had some fun with the source files. Based on Sprig's commit history, this appears to be a common occurrence so I am not reverting the format changes unless there is a major problem.